### PR TITLE
[!!!][TASK] Rename option for active TYPO3 extensions

### DIFF
--- a/res/php/autoload-include.tmpl.php
+++ b/res/php/autoload-include.tmpl.php
@@ -6,5 +6,5 @@ if (!getenv('TYPO3_PATH_ROOT')) {
     putenv('TYPO3_PATH_ROOT=' . '{$root-dir}');
 }
 if (!getenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS')) {
-    putenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS=' . '{$active-typo3-extensions}');
+    putenv('TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS=' . '{$active-framework-extensions}');
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,7 +21,7 @@ class Config
      * @var array
      */
     public static $defaultConfig = array(
-        'active-typo3-extensions' => array()
+        'active-framework-extensions' => array()
     );
 
     /**

--- a/src/IncludeFileWriter.php
+++ b/src/IncludeFileWriter.php
@@ -103,11 +103,11 @@ class IncludeFileWriter
         $includeFileContent = file_get_contents($includeFileTemplate);
         $includeFileContent = self::replaceToken('web-dir', $pathToTypo3WebCode, $includeFileContent);
         $includeFileContent = self::replaceToken('root-dir', $pathToProjectRoot, $includeFileContent);
-        $activeTypo3Extensions = $this->config->get('active-typo3-extensions');
-        if (!is_array($activeTypo3Extensions)) {
-            $this->io->writeError(sprintf('<error>Extra section "active-typo3-extensions" must be array, "%s" given!</error>', gettype($activeTypo3Extensions)));
+        $activeTypo3FrameworkExtensions = $this->config->get('active-framework-extensions');
+        if (!is_array($activeTypo3FrameworkExtensions)) {
+            $this->io->writeError(sprintf('<error>Extra section "active-framework-extensions" must be array, "%s" given!</error>', gettype($activeTypo3FrameworkExtensions)));
         } else {
-            $includeFileContent = self::replaceToken('active-typo3-extensions', var_export(implode(',', $activeTypo3Extensions), true), $includeFileContent);
+            $includeFileContent = self::replaceToken('active-framework-extensions', var_export(implode(',', $activeTypo3FrameworkExtensions), true), $includeFileContent);
         }
 
         return $includeFileContent;


### PR DESCRIPTION
Rename the option to "active-framework-extensions" to be in line
with the TYPO3_ACTIVE_FRAMEWORK_EXTENSIONS environment variable
and hint at its purpose.
